### PR TITLE
fix small problem crashes template select

### DIFF
--- a/plugins/Templater/pages/config.php
+++ b/plugins/Templater/pages/config.php
@@ -62,7 +62,7 @@ function get_template_dir(){
 			</td>
 			<td class="center" colspan="2">
 				<select name="template_name" style="width: 50%;">
-					<?
+					<?php
 						$selected_item_name = plugin_config_get( 'template_name' );
 						$folders = get_template_dir();
 						foreach($folders as $item)


### PR DESCRIPTION
there was block of <? ?> php code which isn't interpreting in most of php5 default *nix configurations. changed with standard <?php ?>
